### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(TissueSegmentation)
 set(EXTENSION_HOMEPAGE "https://github.com/MarinaSandonis/SlicerTissueSegmentation#slicertissuesegmentation")
 set(EXTENSION_CATEGORY "Segmentation")
 set(EXTENSION_CONTRIBUTORS "Marina Sandonís Fernández (UPNA), Fernando Idoate Saralegui (Mutua Navarra), Rafael Cabeza Laguna (UPNA)")
-set(EXTENSION_DESCRIPTION "This extension gets the 2D/3D segmentation of the abdomen and the thigh from MR images")
+set(EXTENSION_DESCRIPTION "This extension allows to generate the 2D/3D segmentation of the abdomen and the thigh from MR images.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/MarinaSandonis/SlicerTissueSegmentation/main/TissueSegmentation.jpg")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/MarinaSandonis/SlicerTissueSegmentation/main/images/module.png https://raw.githubusercontent.com/MarinaSandonis/SlicerTissueSegmentation/main/images/inputs.png https://raw.githubusercontent.com/MarinaSandonis/SlicerTissueSegmentation/main/images/Outputs.png https://raw.githubusercontent.com/MarinaSandonis/SlicerTissueSegmentation/main/images/abdomen_segmenattion.png https://raw.githubusercontent.com/MarinaSandonis/SlicerTissueSegmentation/main/images/thigh_segmenattion.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.